### PR TITLE
Improve test suite 2

### DIFF
--- a/lib/danger-packwerk/private/default_offenses_formatter.rb
+++ b/lib/danger-packwerk/private/default_offenses_formatter.rb
@@ -28,8 +28,7 @@ module DangerPackwerk
         else # violations.any?(&:privacy?)
           <<~MESSAGE
             Hi! It looks like the pack defining `#{constant_name}` considers this private API.
-            #{disclaimer}
-            #{request_to_add_context}
+            #{disclaimer}#{request_to_add_context}
           MESSAGE
         end
       end

--- a/spec/danger_packwerk/danger_deprecated_references_yml_changes_spec.rb
+++ b/spec/danger_packwerk/danger_deprecated_references_yml_changes_spec.rb
@@ -56,18 +56,18 @@ module DangerPackwerk
       describe 'behavior when violations are added or removed' do
         context 'a deprecated_refrences.yml file is added (i.e. a pack has its first violation)' do
           let(:added_files) do
-            file = write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)
-              ---
-              packs/some_other_pack:
-                "OtherPackClass":
-                  violations:
-                  - privacy
-                  - dependency
-                  files:
-                  - packs/some_pack/some_class.rb
-            YML
-
-            [file.to_s]
+            [
+              write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)
+                ---
+                packs/some_other_pack:
+                  "OtherPackClass":
+                    violations:
+                    - privacy
+                    - dependency
+                    files:
+                    - packs/some_pack/some_class.rb
+              YML
+            ]
           end
 
           it 'calls the before comment input proc' do
@@ -177,17 +177,17 @@ module DangerPackwerk
 
         context 'a deprecated_refrences.yml file is modified to remove violations' do
           let(:modified_files) do
-            file = write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)
-              ---
-              packs/some_other_pack:
-                "OtherPackClass":
-                  violations:
-                  - privacy
-                  files:
-                  - packs/some_pack/some_class.rb
-            YML
-
-            [file.to_s]
+            [
+              write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)
+                ---
+                packs/some_other_pack:
+                  "OtherPackClass":
+                    violations:
+                    - privacy
+                    files:
+                    - packs/some_pack/some_class.rb
+              YML
+            ]
           end
 
           let(:some_pack_deprecated_references_before) do
@@ -228,18 +228,18 @@ module DangerPackwerk
 
         context 'a deprecated_refrences.yml file is modified to change violations in many files' do
           let(:modified_files) do
-            file = write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)
-              ---
-              packs/some_other_pack:
-                "OtherPackClass":
-                  violations:
-                  - privacy
-                  - dependency
-                  files:
-                  - packs/some_pack/some_class.rb
-            YML
-
-            [file.to_s]
+            [
+              write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)
+                ---
+                packs/some_other_pack:
+                  "OtherPackClass":
+                    violations:
+                    - privacy
+                    - dependency
+                    files:
+                    - packs/some_pack/some_class.rb
+              YML
+            ]
           end
 
           let(:some_pack_deprecated_references_before) do
@@ -302,32 +302,32 @@ module DangerPackwerk
 
         context 'a deprecated_refrences.yml file is modified to add 30 and remove 15 violations' do
           let(:modified_files) do
-            file = write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)
-              ---
-              packs/some_other_pack:
-                "OtherPackClass":
-                  violations:
-                  - privacy
-                  - dependency
-                  files:
-                  - packs/some_pack/some_class1.rb
-                  - packs/some_pack/some_class2.rb
-                  - packs/some_pack/some_class3.rb
-                  - packs/some_pack/some_class4.rb
-                  - packs/some_pack/some_class5.rb
-                  - packs/some_pack/some_class6.rb
-                  - packs/some_pack/some_class7.rb
-                  - packs/some_pack/some_class8.rb
-                  - packs/some_pack/some_class9.rb
-                  - packs/some_pack/some_class10.rb
-                  - packs/some_pack/some_class11.rb
-                  - packs/some_pack/some_class12.rb
-                  - packs/some_pack/some_class13.rb
-                  - packs/some_pack/some_class14.rb
-                  - packs/some_pack/some_class15.rb
-            YML
-
-            [file.to_s]
+            [
+              write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)
+                ---
+                packs/some_other_pack:
+                  "OtherPackClass":
+                    violations:
+                    - privacy
+                    - dependency
+                    files:
+                    - packs/some_pack/some_class1.rb
+                    - packs/some_pack/some_class2.rb
+                    - packs/some_pack/some_class3.rb
+                    - packs/some_pack/some_class4.rb
+                    - packs/some_pack/some_class5.rb
+                    - packs/some_pack/some_class6.rb
+                    - packs/some_pack/some_class7.rb
+                    - packs/some_pack/some_class8.rb
+                    - packs/some_pack/some_class9.rb
+                    - packs/some_pack/some_class10.rb
+                    - packs/some_pack/some_class11.rb
+                    - packs/some_pack/some_class12.rb
+                    - packs/some_pack/some_class13.rb
+                    - packs/some_pack/some_class14.rb
+                    - packs/some_pack/some_class15.rb
+              YML
+            ]
           end
 
           let(:some_pack_deprecated_references_before) do

--- a/spec/danger_packwerk/danger_deprecated_references_yml_changes_spec.rb
+++ b/spec/danger_packwerk/danger_deprecated_references_yml_changes_spec.rb
@@ -53,7 +53,7 @@ module DangerPackwerk
         end
       end
 
-      context 'a deprecated_refrences.yml file is added (i.e. a pack has its first violation)' do
+      context 'a deprecated_references.yml file is added (i.e. a pack has its first violation)' do
         let(:added_files) do
           [
             write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)

--- a/spec/danger_packwerk/danger_deprecated_references_yml_changes_spec.rb
+++ b/spec/danger_packwerk/danger_deprecated_references_yml_changes_spec.rb
@@ -141,7 +141,7 @@ module DangerPackwerk
         end
       end
 
-      context 'a deprecated_refrences.yml file is deleted (i.e. a pack has all violations removed)' do
+      context 'a deprecated_references.yml file is deleted (i.e. a pack has all violations removed)' do
         let(:deleted_files) { ['packs/some_pack/deprecated_references.yml'] }
         let(:some_pack_deprecated_references_before) do
           write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)

--- a/spec/danger_packwerk/danger_deprecated_references_yml_changes_spec.rb
+++ b/spec/danger_packwerk/danger_deprecated_references_yml_changes_spec.rb
@@ -53,234 +53,32 @@ module DangerPackwerk
         end
       end
 
-      describe 'behavior when violations are added or removed' do
-        context 'a deprecated_refrences.yml file is added (i.e. a pack has its first violation)' do
-          let(:added_files) do
-            [
-              write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)
-                ---
-                packs/some_other_pack:
-                  "OtherPackClass":
-                    violations:
-                    - privacy
-                    - dependency
-                    files:
-                    - packs/some_pack/some_class.rb
-              YML
-            ]
-          end
-
-          it 'calls the before comment input proc' do
-            expect(slack_notifier).to receive(:notify_slack).with(
-              { dependency: { minus: 0, plus: 1 }, privacy: { minus: 0, plus: 1 } },
-              ['packs/some_pack/deprecated_references.yml']
-            )
-
-            subject
-          end
-
-          context 'default formatter is used' do
-            it 'displays a markdown with a reasonable message' do
-              subject
-              expect(dangerfile.status_report[:warnings]).to be_empty
-              expect(dangerfile.status_report[:errors]).to be_empty
-              actual_markdowns = dangerfile.status_report[:markdowns]
-              expect(actual_markdowns.count).to eq 1
-              actual_markdown = actual_markdowns.first
-              expected = <<~EXPECTED
-                Hi! It looks like the pack defining `OtherPackClass` considers this private API, and it's also not in the referencing pack's list of dependencies.
-                We noticed you ran `bin/packwerk update-deprecations`. Make sure to read through [the docs](https://github.com/Shopify/packwerk/blob/b647594f93c8922c038255a7aaca125d391a1fbf/docs/new_violation_flow_chart.pdf) for other ways to resolve. Could you add some context as a reply here about why we needed to add these violations?
-              EXPECTED
-
-              expect(actual_markdown.message).to eq expected
-              expect(actual_markdown.line).to eq 3
-              expect(actual_markdown.file).to eq 'packs/some_pack/deprecated_references.yml'
-              expect(actual_markdown.type).to eq :markdown
-            end
-          end
-
-          context 'a offenses formatter is passed in' do
-            let(:added_offenses_formatter) do
-              lambda do |added_violations|
-                <<~MESSAGE
-                  There are #{added_violations.count} new violations,
-                  with class_names #{added_violations.map(&:class_name).uniq.sort},
-                  with to_package_names #{added_violations.map(&:to_package_name).uniq.sort},
-                  with types #{added_violations.map(&:type).sort},
-                MESSAGE
-              end
-            end
-
-            subject do
-              danger_deprecated_references_yml_changes.check(
-                added_offenses_formatter: added_offenses_formatter,
-                before_comment: lambda do |_violation_diff, changed_deprecated_references_ymls|
-                  slack_notifier.notify_slack(changed_deprecated_references_ymls)
-                end
-              )
-            end
-
-            it 'displays a markdown using the passed in offenses formatter' do
-              subject
-              expect(dangerfile.status_report[:warnings]).to be_empty
-              expect(dangerfile.status_report[:errors]).to be_empty
-              actual_markdowns = dangerfile.status_report[:markdowns]
-              expect(actual_markdowns.count).to eq 1
-              actual_markdown = actual_markdowns.first
-              expected = <<~EXPECTED
-                There are 2 new violations,
-                with class_names ["OtherPackClass"],
-                with to_package_names ["packs/some_other_pack"],
-                with types ["dependency", "privacy"],
-              EXPECTED
-
-              expect(actual_markdown.message).to eq expected
-              expect(actual_markdown.line).to eq 3
-              expect(actual_markdown.file).to eq 'packs/some_pack/deprecated_references.yml'
-              expect(actual_markdown.type).to eq :markdown
-            end
-          end
-        end
-
-        context 'a deprecated_refrences.yml file is deleted (i.e. a pack has all violations removed)' do
-          let(:deleted_files) { ['packs/some_pack/deprecated_references.yml'] }
-          let(:some_pack_deprecated_references_before) do
-            write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)
-              ---
-              packs/some_other_pack:
-                "OtherPackClass":
-                  violations:
-                  - dependency
-                  - privacy
-                  files:
-                  - packs/some_pack/some_class.rb
-            YML
-          end
-
-          it 'calls the before comment input proc' do
-            expect(slack_notifier).to receive(:notify_slack).with(
-              { dependency: { minus: 1, plus: 0 }, privacy: { minus: 1, plus: 0 } },
-              ['packs/some_pack/deprecated_references.yml']
-            )
-
-            subject
-          end
-
-          it 'does not display a markdown message' do
-            subject
-            expect(dangerfile.status_report[:warnings]).to be_empty
-            expect(dangerfile.status_report[:errors]).to be_empty
-            actual_markdowns = dangerfile.status_report[:markdowns]
-            expect(actual_markdowns.count).to eq 0
-          end
-        end
-
-        context 'a deprecated_refrences.yml file is modified to remove violations' do
-          let(:modified_files) do
-            [
-              write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)
-                ---
-                packs/some_other_pack:
-                  "OtherPackClass":
-                    violations:
-                    - privacy
-                    files:
-                    - packs/some_pack/some_class.rb
-              YML
-            ]
-          end
-
-          let(:some_pack_deprecated_references_before) do
+      context 'a deprecated_refrences.yml file is added (i.e. a pack has its first violation)' do
+        let(:added_files) do
+          [
             write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)
               ---
               packs/some_other_pack:
                 "OtherPackClass":
                   violations:
                   - privacy
+                  - dependency
                   files:
                   - packs/some_pack/some_class.rb
-                "OtherPackClass2":
-                  violations:
-                  - dependency
-                  - privacy
-                  files:
-                  - packs/some_pack/some_class2.rb
             YML
-          end
-
-          it 'calls the before comment input proc' do
-            expect(slack_notifier).to receive(:notify_slack).with(
-              { dependency: { minus: 1, plus: 0 }, privacy: { minus: 1, plus: 0 } },
-              ['packs/some_pack/deprecated_references.yml']
-            )
-
-            subject
-          end
-
-          it 'does not display a markdown message' do
-            subject
-            expect(dangerfile.status_report[:warnings]).to be_empty
-            expect(dangerfile.status_report[:errors]).to be_empty
-            actual_markdowns = dangerfile.status_report[:markdowns]
-            expect(actual_markdowns.count).to eq 0
-          end
+          ]
         end
 
-        context 'a deprecated_refrences.yml file is modified to change violations in many files' do
-          let(:modified_files) do
-            [
-              write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)
-                ---
-                packs/some_other_pack:
-                  "OtherPackClass":
-                    violations:
-                    - privacy
-                    - dependency
-                    files:
-                    - packs/some_pack/some_class.rb
-              YML
-            ]
-          end
+        it 'calls the before comment input proc' do
+          expect(slack_notifier).to receive(:notify_slack).with(
+            { dependency: { minus: 0, plus: 1 }, privacy: { minus: 0, plus: 1 } },
+            ['packs/some_pack/deprecated_references.yml']
+          )
 
-          let(:some_pack_deprecated_references_before) do
-            write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)
-              ---
-              packs/some_other_pack:
-                "OtherPackClass":
-                  violations:
-                  - privacy
-                  files:
-                  - packs/some_pack/some_class.rb
-                  - packs/some_pack/some_class2.rb
-                  - packs/some_pack/some_class3.rb
-                  - packs/some_pack/some_class4.rb
-                  - packs/some_pack/some_class5.rb
-                  - packs/some_pack/some_class6.rb
-                  - packs/some_pack/some_class7.rb
-                "OtherPackClass2":
-                  violations:
-                  - dependency
-                  - privacy
-                  files:
-                  - packs/some_pack/some_class2.rb
-                  - packs/some_pack/some_class3.rb
-                  - packs/some_pack/some_class4.rb
-                  - packs/some_pack/some_class5.rb
-                  - packs/some_pack/some_class6.rb
-                  - packs/some_pack/some_class7.rb
+          subject
+        end
 
-            YML
-          end
-
-          it 'calls the before comment input proc' do
-            expect(slack_notifier).to receive(:notify_slack).with(
-              { dependency: { minus: 6, plus: 1 }, privacy: { minus: 12, plus: 0 } },
-              ['packs/some_pack/deprecated_references.yml']
-            )
-
-            subject
-          end
-
+        context 'default formatter is used' do
           it 'displays a markdown with a reasonable message' do
             subject
             expect(dangerfile.status_report[:warnings]).to be_empty
@@ -289,8 +87,8 @@ module DangerPackwerk
             expect(actual_markdowns.count).to eq 1
             actual_markdown = actual_markdowns.first
             expected = <<~EXPECTED
-              Hi! It looks like the pack defining `OtherPackClass` is not in the referencing pack's list of dependencies.
-              We noticed you ran `bin/packwerk update-deprecations`. Make sure to read through [the docs](https://github.com/Shopify/packwerk/blob/b647594f93c8922c038255a7aaca125d391a1fbf/docs/new_violation_flow_chart.pdf) for other ways to resolve. Could you add some context as a reply here about why we needed to add this violation?
+              Hi! It looks like the pack defining `OtherPackClass` considers this private API, and it's also not in the referencing pack's list of dependencies.
+              We noticed you ran `bin/packwerk update-deprecations`. Make sure to read through [the docs](https://github.com/Shopify/packwerk/blob/b647594f93c8922c038255a7aaca125d391a1fbf/docs/new_violation_flow_chart.pdf) for other ways to resolve. Could you add some context as a reply here about why we needed to add these violations?
             EXPECTED
 
             expect(actual_markdown.message).to eq expected
@@ -300,43 +98,217 @@ module DangerPackwerk
           end
         end
 
-        context 'a deprecated_refrences.yml file is modified to add 30 and remove 15 violations' do
-          let(:modified_files) do
-            [
-              write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)
-                ---
-                packs/some_other_pack:
-                  "OtherPackClass":
-                    violations:
-                    - privacy
-                    - dependency
-                    files:
-                    - packs/some_pack/some_class1.rb
-                    - packs/some_pack/some_class2.rb
-                    - packs/some_pack/some_class3.rb
-                    - packs/some_pack/some_class4.rb
-                    - packs/some_pack/some_class5.rb
-                    - packs/some_pack/some_class6.rb
-                    - packs/some_pack/some_class7.rb
-                    - packs/some_pack/some_class8.rb
-                    - packs/some_pack/some_class9.rb
-                    - packs/some_pack/some_class10.rb
-                    - packs/some_pack/some_class11.rb
-                    - packs/some_pack/some_class12.rb
-                    - packs/some_pack/some_class13.rb
-                    - packs/some_pack/some_class14.rb
-                    - packs/some_pack/some_class15.rb
-              YML
-            ]
+        context 'a offenses formatter is passed in' do
+          let(:added_offenses_formatter) do
+            lambda do |added_violations|
+              <<~MESSAGE
+                There are #{added_violations.count} new violations,
+                with class_names #{added_violations.map(&:class_name).uniq.sort},
+                with to_package_names #{added_violations.map(&:to_package_name).uniq.sort},
+                with types #{added_violations.map(&:type).sort},
+              MESSAGE
+            end
           end
 
-          let(:some_pack_deprecated_references_before) do
+          subject do
+            danger_deprecated_references_yml_changes.check(
+              added_offenses_formatter: added_offenses_formatter,
+              before_comment: lambda do |_violation_diff, changed_deprecated_references_ymls|
+                slack_notifier.notify_slack(changed_deprecated_references_ymls)
+              end
+            )
+          end
+
+          it 'displays a markdown using the passed in offenses formatter' do
+            subject
+            expect(dangerfile.status_report[:warnings]).to be_empty
+            expect(dangerfile.status_report[:errors]).to be_empty
+            actual_markdowns = dangerfile.status_report[:markdowns]
+            expect(actual_markdowns.count).to eq 1
+            actual_markdown = actual_markdowns.first
+            expected = <<~EXPECTED
+              There are 2 new violations,
+              with class_names ["OtherPackClass"],
+              with to_package_names ["packs/some_other_pack"],
+              with types ["dependency", "privacy"],
+            EXPECTED
+
+            expect(actual_markdown.message).to eq expected
+            expect(actual_markdown.line).to eq 3
+            expect(actual_markdown.file).to eq 'packs/some_pack/deprecated_references.yml'
+            expect(actual_markdown.type).to eq :markdown
+          end
+        end
+      end
+
+      context 'a deprecated_refrences.yml file is deleted (i.e. a pack has all violations removed)' do
+        let(:deleted_files) { ['packs/some_pack/deprecated_references.yml'] }
+        let(:some_pack_deprecated_references_before) do
+          write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)
+            ---
+            packs/some_other_pack:
+              "OtherPackClass":
+                violations:
+                - dependency
+                - privacy
+                files:
+                - packs/some_pack/some_class.rb
+          YML
+        end
+
+        it 'calls the before comment input proc' do
+          expect(slack_notifier).to receive(:notify_slack).with(
+            { dependency: { minus: 1, plus: 0 }, privacy: { minus: 1, plus: 0 } },
+            ['packs/some_pack/deprecated_references.yml']
+          )
+
+          subject
+        end
+
+        it 'does not display a markdown message' do
+          subject
+          expect(dangerfile.status_report[:warnings]).to be_empty
+          expect(dangerfile.status_report[:errors]).to be_empty
+          actual_markdowns = dangerfile.status_report[:markdowns]
+          expect(actual_markdowns.count).to eq 0
+        end
+      end
+
+      context 'a deprecated_refrences.yml file is modified to remove violations' do
+        let(:modified_files) do
+          [
             write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)
               ---
               packs/some_other_pack:
                 "OtherPackClass":
                   violations:
                   - privacy
+                  files:
+                  - packs/some_pack/some_class.rb
+            YML
+          ]
+        end
+
+        let(:some_pack_deprecated_references_before) do
+          write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)
+            ---
+            packs/some_other_pack:
+              "OtherPackClass":
+                violations:
+                - privacy
+                files:
+                - packs/some_pack/some_class.rb
+              "OtherPackClass2":
+                violations:
+                - dependency
+                - privacy
+                files:
+                - packs/some_pack/some_class2.rb
+          YML
+        end
+
+        it 'calls the before comment input proc' do
+          expect(slack_notifier).to receive(:notify_slack).with(
+            { dependency: { minus: 1, plus: 0 }, privacy: { minus: 1, plus: 0 } },
+            ['packs/some_pack/deprecated_references.yml']
+          )
+
+          subject
+        end
+
+        it 'does not display a markdown message' do
+          subject
+          expect(dangerfile.status_report[:warnings]).to be_empty
+          expect(dangerfile.status_report[:errors]).to be_empty
+          actual_markdowns = dangerfile.status_report[:markdowns]
+          expect(actual_markdowns.count).to eq 0
+        end
+      end
+
+      context 'a deprecated_refrences.yml file is modified to change violations in many files' do
+        let(:modified_files) do
+          [
+            write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)
+              ---
+              packs/some_other_pack:
+                "OtherPackClass":
+                  violations:
+                  - privacy
+                  - dependency
+                  files:
+                  - packs/some_pack/some_class.rb
+            YML
+          ]
+        end
+
+        let(:some_pack_deprecated_references_before) do
+          write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)
+            ---
+            packs/some_other_pack:
+              "OtherPackClass":
+                violations:
+                - privacy
+                files:
+                - packs/some_pack/some_class.rb
+                - packs/some_pack/some_class2.rb
+                - packs/some_pack/some_class3.rb
+                - packs/some_pack/some_class4.rb
+                - packs/some_pack/some_class5.rb
+                - packs/some_pack/some_class6.rb
+                - packs/some_pack/some_class7.rb
+              "OtherPackClass2":
+                violations:
+                - dependency
+                - privacy
+                files:
+                - packs/some_pack/some_class2.rb
+                - packs/some_pack/some_class3.rb
+                - packs/some_pack/some_class4.rb
+                - packs/some_pack/some_class5.rb
+                - packs/some_pack/some_class6.rb
+                - packs/some_pack/some_class7.rb
+
+          YML
+        end
+
+        it 'calls the before comment input proc' do
+          expect(slack_notifier).to receive(:notify_slack).with(
+            { dependency: { minus: 6, plus: 1 }, privacy: { minus: 12, plus: 0 } },
+            ['packs/some_pack/deprecated_references.yml']
+          )
+
+          subject
+        end
+
+        it 'displays a markdown with a reasonable message' do
+          subject
+          expect(dangerfile.status_report[:warnings]).to be_empty
+          expect(dangerfile.status_report[:errors]).to be_empty
+          actual_markdowns = dangerfile.status_report[:markdowns]
+          expect(actual_markdowns.count).to eq 1
+          actual_markdown = actual_markdowns.first
+          expected = <<~EXPECTED
+            Hi! It looks like the pack defining `OtherPackClass` is not in the referencing pack's list of dependencies.
+            We noticed you ran `bin/packwerk update-deprecations`. Make sure to read through [the docs](https://github.com/Shopify/packwerk/blob/b647594f93c8922c038255a7aaca125d391a1fbf/docs/new_violation_flow_chart.pdf) for other ways to resolve. Could you add some context as a reply here about why we needed to add this violation?
+          EXPECTED
+
+          expect(actual_markdown.message).to eq expected
+          expect(actual_markdown.line).to eq 3
+          expect(actual_markdown.file).to eq 'packs/some_pack/deprecated_references.yml'
+          expect(actual_markdown.type).to eq :markdown
+        end
+      end
+
+      context 'a deprecated_refrences.yml file is modified to add 30 and remove 15 violations' do
+        let(:modified_files) do
+          [
+            write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)
+              ---
+              packs/some_other_pack:
+                "OtherPackClass":
+                  violations:
+                  - privacy
+                  - dependency
                   files:
                   - packs/some_pack/some_class1.rb
                   - packs/some_pack/some_class2.rb
@@ -353,55 +325,81 @@ module DangerPackwerk
                   - packs/some_pack/some_class13.rb
                   - packs/some_pack/some_class14.rb
                   - packs/some_pack/some_class15.rb
-                "AnotherPackClass":
-                  violations:
-                  - privacy
-                  - dependency
-                  files:
-                  - packs/some_pack/some_other_class1.rb
-                  - packs/some_pack/some_other_class2.rb
-                  - packs/some_pack/some_other_class3.rb
-                  - packs/some_pack/some_other_class4.rb
-                  - packs/some_pack/some_other_class5.rb
-                  - packs/some_pack/some_other_class6.rb
-                  - packs/some_pack/some_other_class7.rb
-                  - packs/some_pack/some_other_class8.rb
-                  - packs/some_pack/some_other_class9.rb
-                  - packs/some_pack/some_other_class10.rb
-                  - packs/some_pack/some_other_class11.rb
-                  - packs/some_pack/some_other_class12.rb
-                  - packs/some_pack/some_other_class13.rb
-                  - packs/some_pack/some_other_class14.rb
-                  - packs/some_pack/some_other_class15.rb
             YML
-          end
+          ]
+        end
 
-          it 'calls the before comment input proc' do
-            expect(slack_notifier).to receive(:notify_slack).with(
-              { dependency: { minus: 15, plus: 15 }, privacy: { minus: 15, plus: 0 } },
-              ['packs/some_pack/deprecated_references.yml']
-            )
+        let(:some_pack_deprecated_references_before) do
+          write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)
+            ---
+            packs/some_other_pack:
+              "OtherPackClass":
+                violations:
+                - privacy
+                files:
+                - packs/some_pack/some_class1.rb
+                - packs/some_pack/some_class2.rb
+                - packs/some_pack/some_class3.rb
+                - packs/some_pack/some_class4.rb
+                - packs/some_pack/some_class5.rb
+                - packs/some_pack/some_class6.rb
+                - packs/some_pack/some_class7.rb
+                - packs/some_pack/some_class8.rb
+                - packs/some_pack/some_class9.rb
+                - packs/some_pack/some_class10.rb
+                - packs/some_pack/some_class11.rb
+                - packs/some_pack/some_class12.rb
+                - packs/some_pack/some_class13.rb
+                - packs/some_pack/some_class14.rb
+                - packs/some_pack/some_class15.rb
+              "AnotherPackClass":
+                violations:
+                - privacy
+                - dependency
+                files:
+                - packs/some_pack/some_other_class1.rb
+                - packs/some_pack/some_other_class2.rb
+                - packs/some_pack/some_other_class3.rb
+                - packs/some_pack/some_other_class4.rb
+                - packs/some_pack/some_other_class5.rb
+                - packs/some_pack/some_other_class6.rb
+                - packs/some_pack/some_other_class7.rb
+                - packs/some_pack/some_other_class8.rb
+                - packs/some_pack/some_other_class9.rb
+                - packs/some_pack/some_other_class10.rb
+                - packs/some_pack/some_other_class11.rb
+                - packs/some_pack/some_other_class12.rb
+                - packs/some_pack/some_other_class13.rb
+                - packs/some_pack/some_other_class14.rb
+                - packs/some_pack/some_other_class15.rb
+          YML
+        end
 
-            subject
-          end
+        it 'calls the before comment input proc' do
+          expect(slack_notifier).to receive(:notify_slack).with(
+            { dependency: { minus: 15, plus: 15 }, privacy: { minus: 15, plus: 0 } },
+            ['packs/some_pack/deprecated_references.yml']
+          )
 
-          it 'displays a markdown with a reasonable message' do
-            subject
-            expect(dangerfile.status_report[:warnings]).to be_empty
-            expect(dangerfile.status_report[:errors]).to be_empty
-            actual_markdowns = dangerfile.status_report[:markdowns]
-            expect(actual_markdowns.count).to eq 1
-            actual_markdown = actual_markdowns.first
-            expected = <<~EXPECTED
-              Hi! It looks like the pack defining `OtherPackClass` is not in the referencing pack's list of dependencies.
-              We noticed you ran `bin/packwerk update-deprecations`. Make sure to read through [the docs](https://github.com/Shopify/packwerk/blob/b647594f93c8922c038255a7aaca125d391a1fbf/docs/new_violation_flow_chart.pdf) for other ways to resolve. Could you add some context as a reply here about why we needed to add these violations?
-            EXPECTED
+          subject
+        end
 
-            expect(actual_markdown.message).to eq expected
-            expect(actual_markdown.line).to eq 3
-            expect(actual_markdown.file).to eq 'packs/some_pack/deprecated_references.yml'
-            expect(actual_markdown.type).to eq :markdown
-          end
+        it 'displays a markdown with a reasonable message' do
+          subject
+          expect(dangerfile.status_report[:warnings]).to be_empty
+          expect(dangerfile.status_report[:errors]).to be_empty
+          actual_markdowns = dangerfile.status_report[:markdowns]
+          expect(actual_markdowns.count).to eq 1
+          actual_markdown = actual_markdowns.first
+          expected = <<~EXPECTED
+            Hi! It looks like the pack defining `OtherPackClass` is not in the referencing pack's list of dependencies.
+            We noticed you ran `bin/packwerk update-deprecations`. Make sure to read through [the docs](https://github.com/Shopify/packwerk/blob/b647594f93c8922c038255a7aaca125d391a1fbf/docs/new_violation_flow_chart.pdf) for other ways to resolve. Could you add some context as a reply here about why we needed to add these violations?
+          EXPECTED
+
+          expect(actual_markdown.message).to eq expected
+          expect(actual_markdown.line).to eq 3
+          expect(actual_markdown.file).to eq 'packs/some_pack/deprecated_references.yml'
+          expect(actual_markdown.type).to eq :markdown
         end
       end
     end


### PR DESCRIPTION
# Summary
This is the first of two PRs to clean up the test suite.

This PR does the following:
1) It takes common test setup that is an implementation detail (and thus distracts from the behavior of the test) into a common helper
2) It cleans up some let blocks
3) It removes an unnecessary, redundant context
4) It adds some test cases for edge cases that are not covered whose behavior might change when I open a PR for https://github.com/BigRails/danger-packwerk/issues/2

The next PR will:
1) Improve `it` block descriptions to be more clear about what the expected outcome is
2) It will create a custom matcher `have_inline_markdown` that encapsulates some common test details, such as:
- It ensures there are no other types of danger messages besides `markdown`
- It identifies what line number the comment is on so its simpler to visualize the danger message

# Commits
- clean up common test setup
- clean up let blocks
- remove unnecessary context
- Add some test cases
