### PR TITLE
Fix edge case bug where the presence of constants that are substrings of other constants can cause wrong comment location

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    danger-packwerk (0.1.1)
+    danger-packwerk (0.1.2)
       danger-plugin-api (~> 1.0)
       packwerk
       sorbet-runtime

--- a/lib/danger-packwerk/version.rb
+++ b/lib/danger-packwerk/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module DangerPackwerk
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end

--- a/spec/danger_packwerk/danger_deprecated_references_yml_changes_spec.rb
+++ b/spec/danger_packwerk/danger_deprecated_references_yml_changes_spec.rb
@@ -351,19 +351,19 @@ module DangerPackwerk
         end
       end
 
-      context 'a deprecated_refrences.yml file is modified to add a reference (that already exists in `deprecated_references.yml`) against an existing constant in an existing file' do
+      context 'a deprecated_refrences.yml file is modified to add another violation on a file with an existing violation' do
         let(:modified_files) do
           [
             write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)
               ---
               packs/some_other_pack:
-                "OtherPackClass":
+                "ABCClass":
                   violations:
                   - privacy
                   files:
                   - packs/some_pack/some_class.rb
                   - packs/some_pack/some_other_class.rb
-                "SomeOtherPackClass":
+                "XYZModule":
                   violations:
                   - privacy
                   files:
@@ -377,13 +377,13 @@ module DangerPackwerk
           write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)
             ---
             packs/some_other_pack:
-              "OtherPackClass":
+              "ABCClass":
                 violations:
                 - privacy
                 files:
                 - packs/some_pack/some_class.rb
                 - packs/some_pack/some_other_class.rb
-              "SomeOtherPackClass":
+              "XYZModule":
                 violations:
                 - privacy
                 files:
@@ -407,20 +407,20 @@ module DangerPackwerk
             <<~EXPECTED
               ---
               packs/some_other_pack:
-                "OtherPackClass":
+                "ABCClass":
                   violations:
                   - privacy
                   files:
                   - packs/some_pack/some_class.rb
                   - packs/some_pack/some_other_class.rb
-                "SomeOtherPackClass":
+                "XYZModule":
                   violations:
                   - privacy
                   files:
                   - packs/some_pack/some_class.rb
                   - packs/some_pack/some_other_class.rb
               ==================== DANGER_START
-              Hi! It looks like the pack defining `SomeOtherPackClass` considers this private API.
+              Hi! It looks like the pack defining `XYZModule` considers this private API.
               We noticed you ran `bin/packwerk update-deprecations`. Make sure to read through [the docs](https://github.com/Shopify/packwerk/blob/b647594f93c8922c038255a7aaca125d391a1fbf/docs/new_violation_flow_chart.pdf) for other ways to resolve. Could you add some context as a reply here about why we needed to add this violation?
               ==================== DANGER_END
             EXPECTED

--- a/spec/danger_packwerk/danger_deprecated_references_yml_changes_spec.rb
+++ b/spec/danger_packwerk/danger_deprecated_references_yml_changes_spec.rb
@@ -428,6 +428,83 @@ module DangerPackwerk
         end
       end
 
+      context 'a deprecated_refrences.yml file is modified to add another violation on a file with an existing violation, and the constants have clashing names' do
+        let(:modified_files) do
+          [
+            write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)
+              ---
+              packs/some_other_pack:
+                "::TopLevelModule::Helpers::MyHelper":
+                  violations:
+                  - privacy
+                  files:
+                  - packs/some_pack/some_class.rb
+                  - packs/some_pack/some_other_class.rb
+                "::Helpers":
+                  violations:
+                  - privacy
+                  files:
+                  - packs/some_pack/some_class.rb
+                  - packs/some_pack/some_other_class.rb
+            YML
+          ]
+        end
+
+        let(:some_pack_deprecated_references_before) do
+          write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)
+            ---
+            packs/some_other_pack:
+              "::TopLevelModule::Helpers::MyHelper":
+                violations:
+                - privacy
+                files:
+                - packs/some_pack/some_class.rb
+                - packs/some_pack/some_other_class.rb
+              "::Helpers":
+                violations:
+                - privacy
+                files:
+                - packs/some_pack/some_class.rb
+          YML
+        end
+
+        it 'calls the before comment input proc' do
+          expect(slack_notifier).to receive(:notify_slack).with(
+            { dependency: { minus: 0, plus: 0 }, privacy: { minus: 0, plus: 1 } },
+            ['packs/some_pack/deprecated_references.yml']
+          )
+
+          subject
+        end
+
+        it 'displays a markdown with a reasonable message' do
+          subject
+
+          expect('packs/some_pack/deprecated_references.yml').to contain_inline_markdown(
+            <<~EXPECTED
+              ---
+              packs/some_other_pack:
+                "::TopLevelModule::Helpers::MyHelper":
+                  violations:
+                  - privacy
+                  files:
+                  - packs/some_pack/some_class.rb
+                  - packs/some_pack/some_other_class.rb
+                "::Helpers":
+                  violations:
+                  - privacy
+                  files:
+                  - packs/some_pack/some_class.rb
+                  - packs/some_pack/some_other_class.rb
+              ==================== DANGER_START
+              Hi! It looks like the pack defining `Helpers` considers this private API.
+              We noticed you ran `bin/packwerk update-deprecations`. Make sure to read through [the docs](https://github.com/Shopify/packwerk/blob/b647594f93c8922c038255a7aaca125d391a1fbf/docs/new_violation_flow_chart.pdf) for other ways to resolve. Could you add some context as a reply here about why we needed to add this violation?
+              ==================== DANGER_END
+            EXPECTED
+          ).and_nothing_else
+        end
+      end
+
       context 'a deprecated_refrences.yml file is modified to change violations in many files' do
         let(:modified_files) do
           [


### PR DESCRIPTION
# Summary
This is a bit of an interesting one.

I added a test case in the second commit that covers this.

If one constant is a substring of another, then using `line.include?(violation.class_name)` to find the location in `deprecated_references.yml` where a constant is will lead to a false match. This fixes this by matching quotes too.

# Commits
- improve existing test case
- add another failing test
- fix failing test
- bump version
