### PR TITLE
Fix issue where some deprecated_references.yml files use single instead of double quotes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    danger-packwerk (0.1.2)
+    danger-packwerk (0.1.3)
       danger-plugin-api (~> 1.0)
       packwerk
       sorbet-runtime

--- a/lib/danger-packwerk/basic_reference_offense.rb
+++ b/lib/danger-packwerk/basic_reference_offense.rb
@@ -84,8 +84,6 @@ module DangerPackwerk
           # the constant and only the constant.
           # Right now `packwerk` `deprecated_references.yml` files typically use double quotes, but sometimes folks linters change this to single quotes.
           # To be defensive, we match against either.
-          # require 'pry'
-          # binding.pry if line.include?(violation.class_name)
           class_name_with_quote_boundaries = /["|']#{violation.class_name}["|']:/
           line.match?(class_name_with_quote_boundaries)
         end

--- a/lib/danger-packwerk/basic_reference_offense.rb
+++ b/lib/danger-packwerk/basic_reference_offense.rb
@@ -81,10 +81,13 @@ module DangerPackwerk
         _line, class_name_line_number = deprecated_references_yml_pathname.readlines.each_with_index.find do |line, _index|
           # If you have a class `::MyClass`, then you can get a false match if another constant in the file
           # is named `MyOtherClass::MyClassThing`. Therefore we include quotes in our match to ensure that we match
-          # the constant and only the constant. Right now `packwerk` `deprecated_references.yml` files always use
-          # double quotes, so we check for that only. If the public API ever changes, this may need to change.
-          class_name_with_quote_boundaries = "\"#{violation.class_name}\":"
-          line.include?(class_name_with_quote_boundaries)
+          # the constant and only the constant.
+          # Right now `packwerk` `deprecated_references.yml` files typically use double quotes, but sometimes folks linters change this to single quotes.
+          # To be defensive, we match against either.
+          # require 'pry'
+          # binding.pry if line.include?(violation.class_name)
+          class_name_with_quote_boundaries = /["|']#{violation.class_name}["|']:/
+          line.match?(class_name_with_quote_boundaries)
         end
 
         if class_name_line_number.nil?

--- a/lib/danger-packwerk/version.rb
+++ b/lib/danger-packwerk/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module DangerPackwerk
-  VERSION = '0.1.2'
+  VERSION = '0.1.3'
 end


### PR DESCRIPTION
Some `deprecated_references.yml` files have single quotes, often due to developer error (i.e. their linter makes a change and they commit it). Ideally, we could lint against this sort of thing. In either case, it's helpful to be defensive here as it avoids having danger-packwerk barf and produce a sad looking error message when it can't find a constant.
