### PR TITLE
Bump danger-packwerk

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    danger-packwerk (0.1.3)
+    danger-packwerk (0.2.3)
       danger-plugin-api (~> 1.0)
       packwerk
       sorbet-runtime
@@ -44,7 +44,7 @@ GEM
     cork (0.3.0)
       colored2 (~> 3.1)
     crass (1.0.6)
-    danger (8.6.0)
+    danger (8.6.1)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
       colored2 (~> 3.1)
@@ -92,7 +92,7 @@ GEM
     html_tokenizer (0.0.7)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
-    kramdown (2.3.2)
+    kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)

--- a/lib/danger-packwerk/version.rb
+++ b/lib/danger-packwerk/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module DangerPackwerk
-  VERSION = '0.1.3'
+  VERSION = '0.2.3'
 end


### PR DESCRIPTION
This PR bumps `danger-packwerk` to a version number that is arbitrarily above the version Gusto had in its private gemstash before open-sourcing `danger-packwerk`. This should resolve any install issues for Gusto engineers.

Note this line in the Gusto org that showed the previous version: https://github.com/Gusto/danger-packwerk/commit/d917b1a5b38a52c53cf038d2cb87a976bdf9fe8c
